### PR TITLE
Fix the is_vm() method on kvm virtual machines.

### DIFF
--- a/py_vmdetect/py_vmdetect.py
+++ b/py_vmdetect/py_vmdetect.py
@@ -19,7 +19,13 @@ class VMDetect():
         5: "VM_HYPERV",
         6: "VM_USERMODELINUX",
         7: "VM_FREEBSDJAIL",
+        8: "VM_VPC",
+        9: "VM_BHIVE",
+        10: "VM_QEMU",
+        11: "VM_LKVM",
+        12: "VM_VMM"
     }
+
     def __init__(self):
         ffi = FFI()
         ffi.cdef("int vm_by_cpuid();\
@@ -44,7 +50,8 @@ class VMDetect():
         return r
 
     def is_vm(self):
-        return self.isVMware() or \
+        return self.vm_provider_id() != 0 or \
+               self.isVMware() or \
                self.isHyperV() or \
                self.isOpenVZ() or \
                self.isUserModeLinux() or \

--- a/py_vmdetect/src/vmdetect.cpp
+++ b/py_vmdetect/src/vmdetect.cpp
@@ -208,6 +208,12 @@ int _isVMware()
 
 int _isUserModeLinuxOrKvm()
 {
+    // First check by cpuid
+    if(_vm_by_cpuid() == VM_KVM) {
+        return VM_KVM;
+    }
+
+    // Then check /proc/cpuinfo
     int ret = 0;
 #if defined(linux) || defined(__linux) || defined(__linux__)
     char achBuf[4096];

--- a/tests/test_py_vmdetect.py
+++ b/tests/test_py_vmdetect.py
@@ -83,6 +83,13 @@ class TestPy_vmdetect(unittest.TestCase):
             vmd.isFreeBSDJAIL()
         mock_method.assert_called()
 
+    def test_010_isVMware(self):
+        """Test isVMware."""
+        with patch.object(VMDetect, 'isVMware', return_value=True) as mock_method:
+            vmd = VMDetect()
+            vmd.isVMware()
+        mock_method.assert_called()
+
     def test_command_line_interface(self):
         """Test the CLI."""
         runner = CliRunner()


### PR DESCRIPTION
When the cpu data on virtual machine is mirroring the host the is_vm() methods returns false. This requests add an extra detection of kvm, qemu and a few others hypervisors using the cpuid method.
