### PR TITLE
vmdetect.cpp: Fix build with glibc 2.32 and newer

### DIFF
--- a/py_vmdetect/src/vmdetect.cpp
+++ b/py_vmdetect/src/vmdetect.cpp
@@ -7,7 +7,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 #include <sys/sysctl.h>
+#endif
 #include <sys/wait.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Include of <sys/sysctl.h> has been deprecated in glibc 2.30 and removed completely in 2.32 as per https://sourceware.org/pipermail/libc-announce/2020/000029.html

Fixes the following build error on glibc 2.32 and newer: 
| py_vmdetect/src/vmdetect.cpp:10:10: fatal error: sys/sysctl.h: No such file or directory
|    10 | #include <sys/sysctl.h>

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>